### PR TITLE
Change zip output folder structure to fit Chrome Web Store

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,6 @@ module.exports = {
     new ZipPlugin({
       path: path.join(__dirname, 'dist'),
       filename: `${packageJSON.name}-${packageJSON.version}.zip`,
-      pathPrefix: packageJSON.name,
     }),
   ],
 }


### PR DESCRIPTION
Chrome Web Store expects a zip file with the `manifest.json` in the top level directory. This PR implements that by just removing the top directory which was only added for easier and more intuitive unpacking.