### PR TITLE
Support episode change if page doesn't reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-together",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-together",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "scripts": {
     "start": "npm run startServer",
     "startServer": "ts-node ./src/server/index.ts",

--- a/src/plugin/contentScript.ts
+++ b/src/plugin/contentScript.ts
@@ -6,7 +6,8 @@ import {
   setNewVideoTimeIfNecessary,
   setupVideoEventHandlers,
   SkipEvents,
-  skipEvents, SkippableVideoControls,
+  skipEvents,
+  SkippableVideoControls,
 } from './contentScript/videoController'
 import { getPotentialSessionID, initializePlugin } from './contentScript/sessionController'
 import { getVideoControls} from './contentScript/playerAdaption'
@@ -40,7 +41,7 @@ const registerNewSession = async (): Promise<string> => {
   }
 
   const hasResult = (o: unknown): o is { result: string } => {
-    return typeof response === 'object' && response !== null && typeof (
+    return typeof o === 'object' && o !== null && typeof (
       o as { result: unknown }
     ).result === 'string'
   }

--- a/src/plugin/contentScript.ts
+++ b/src/plugin/contentScript.ts
@@ -61,25 +61,6 @@ const sendCheckSessionMessage = async (sessionID: string): Promise<boolean> => {
   return typeof response === 'boolean' ? response : false
 }
 
-export const getOrCreateSessionID = async (): Promise<string> => {
-  let sessionID
-  const potentialSessionID = getPotentialSessionID() ?? ''
-
-  if (potentialSessionID) {
-    const sessionExists = await sendCheckSessionMessage(potentialSessionID)
-
-    if (sessionExists) {
-      sessionID = potentialSessionID
-    }
-  }
-
-  if (!sessionID) {
-    sessionID = await registerNewSession()
-  }
-
-  return sessionID
-}
-
 const onSync = (
   video: HTMLVideoElement,
   videoControls: SkippableVideoControls,

--- a/src/plugin/contentScript.ts
+++ b/src/plugin/contentScript.ts
@@ -121,10 +121,16 @@ const onForeignVideoEvent = async (
   message: VideoEvent,
   port: Port,
   videoControls: SkippableVideoControls,
+  brieflyIgnoreEventsAtEndOfVideo: boolean,
 ) => {
   const videoTime: number | undefined = message?.data?.videoTime
 
-  if (video) {
+  // Ignore events from later than 5 minutes if brieflyIgnoreEventsAtEndOfVideo is true
+  if (video && (
+    !brieflyIgnoreEventsAtEndOfVideo || (
+      videoTime ?? 0
+    ) < 5 * 60
+  )) {
     switch (message.type) {
       case 'playLikeEvent':
         setNewVideoTimeIfNecessary(video, videoControls, shouldSkipEvents, videoTime)
@@ -152,12 +158,23 @@ const onForeignVideoEvent = async (
         console.info(message)
     }
   } else {
-    console.warn('no video found!')
+    if (!video) {
+      console.warn('No video found!')
+    } else {
+      console.log('Skipping event that might have come from a user in an old video')
+    }
   }
 }
 
-export const sendSetupSocketMessage = async (sessionID: string, video: HTMLVideoElement): Promise<() => void> => {
+export const sendSetupSocketMessage = async ({ sessionID, video, brieflyIgnoreEventsAtEndOfVideo }: { sessionID: string, video: HTMLVideoElement, brieflyIgnoreEventsAtEndOfVideo: boolean }): Promise<() => void> => {
   const port = chrome.runtime.connect({ name: 'stream-together' })
+
+  // Stop ignoring events from end of video after a minute. This feature is only intended to avoid issues from some
+  // users staying at the old video too long
+  const brieflyIgnoreEventsAtEndOfVideoRef = { current: brieflyIgnoreEventsAtEndOfVideo }
+  const timeout = setTimeout(() => {
+    brieflyIgnoreEventsAtEndOfVideoRef.current = false
+  }, 60 * 1000)
 
   port.postMessage({
     query: 'setupSocket',
@@ -170,17 +187,19 @@ export const sendSetupSocketMessage = async (sessionID: string, video: HTMLVideo
 
   port.onDisconnect.addListener(() => {
     console.log('Port disconnected; removing event listeners')
+    clearTimeout(timeout)
     removeEventListeners()
   })
 
   port.onMessage.addListener((message) => {
-    onForeignVideoEvent(video, skipEvents, message, port, videoControls)
+    onForeignVideoEvent(video, skipEvents, message, port, videoControls, brieflyIgnoreEventsAtEndOfVideoRef.current)
   })
 
   // Return method to leave session. Said method must disconnect the port (causing the WebSocket to be disconnected)
   // and must then remove the event listeners, as a manual disconnect doesn't fire the onDisconnect handler.
   return () => {
     console.log('Manually disconnecting port and removing event listeners')
+    clearTimeout(timeout)
     port.disconnect()
     removeEventListeners()
   }
@@ -189,7 +208,10 @@ export const sendSetupSocketMessage = async (sessionID: string, video: HTMLVideo
 /**
  * Observes DOM and looks for first video. As soon as a video element is found, the plugin is initialized.
  */
-export const joinPreExistingSessionASAP = (sessionID?: string) => {
+export const joinPreExistingSessionASAP = ({ sessionID, brieflyIgnoreEventsAtEndOfVideo = false }: {
+  sessionID?: string
+  brieflyIgnoreEventsAtEndOfVideo?: boolean
+} = { brieflyIgnoreEventsAtEndOfVideo: false }) => {
   const potentialSessionID = sessionID ?? getPotentialSessionID()
 
   // If session ID is already set, initialize plugin immediately.
@@ -201,7 +223,7 @@ export const joinPreExistingSessionASAP = (sessionID?: string) => {
 
       if (firstVideo) {
         obsRef.current?.disconnect()
-        initializePlugin(potentialSessionID).catch(console.error)
+        initializePlugin({ sessionID: potentialSessionID, brieflyIgnoreEventsAtEndOfVideo }).catch(console.error)
       }
     })
 
@@ -220,6 +242,6 @@ joinPreExistingSessionASAP()
 
 listenForBrowserActionEvents(async () => {
   const sessionID = await registerNewSession()
-  await initializePlugin(sessionID)
+  await initializePlugin({ sessionID })
   return sessionID
 }, initializePlugin)

--- a/src/plugin/contentScript.ts
+++ b/src/plugin/contentScript.ts
@@ -53,7 +53,7 @@ const registerNewSession = async (): Promise<string> => {
   }
 }
 
-const sendCheckSessionMessage = async (sessionID: string): Promise<boolean> => {
+export const sendCheckSessionMessage = async (sessionID: string): Promise<boolean> => {
   const response = await asyncSendMessage({
     query: 'checkSession',
     sessionID,
@@ -189,8 +189,8 @@ export const sendSetupSocketMessage = async (sessionID: string, video: HTMLVideo
 /**
  * Observes DOM and looks for first video. As soon as a video element is found, the plugin is initialized.
  */
-const joinPreExistingSessionASAP = () => {
-  const potentialSessionID = getPotentialSessionID()
+export const joinPreExistingSessionASAP = (sessionID?: string) => {
+  const potentialSessionID = sessionID ?? getPotentialSessionID()
 
   // If session ID is already set, initialize plugin immediately.
   if (potentialSessionID !== undefined) {
@@ -201,7 +201,7 @@ const joinPreExistingSessionASAP = () => {
 
       if (firstVideo) {
         obsRef.current?.disconnect()
-        initializePlugin().catch(console.error)
+        initializePlugin(potentialSessionID).catch(console.error)
       }
     })
 

--- a/src/plugin/contentScript.ts
+++ b/src/plugin/contentScript.ts
@@ -10,7 +10,7 @@ import {
   SkippableVideoControls,
 } from './contentScript/videoController'
 import { getPotentialSessionID, initializePlugin } from './contentScript/sessionController'
-import { getVideoControls} from './contentScript/playerAdaption'
+import { getVideoControls } from './contentScript/playerAdaption'
 
 export const asyncSendMessage = (message: MessageType): Promise<unknown> => {
   return new Promise((resolve, reject) => {

--- a/src/plugin/contentScript/listenForBrowserActionEvents.ts
+++ b/src/plugin/contentScript/listenForBrowserActionEvents.ts
@@ -40,9 +40,9 @@ const evaluateMessage = async (
       sendResponse(getCurrentConnectionStatus())
       break
     default:
-      sendResponse({
-        error: 'Unknown query',
-      })
+      // TODO: throw an error if query is unknown and message is not intended for contentScript
+      // This will have to wait for issue #15
+      console.warn(`Unknown query ${request.query}`)
       break
   }
 }

--- a/src/plugin/contentScript/listenForBrowserActionEvents.ts
+++ b/src/plugin/contentScript/listenForBrowserActionEvents.ts
@@ -9,7 +9,7 @@ const evaluateMessage = async (
   request: BrowserActionRequest,
   sendResponse: (response: unknown) => void,
   createSession: () => Promise<string>,
-  joinSession: (sessionID: string) => Promise<unknown>,
+  joinSession: ({ sessionID }: { sessionID: string }) => Promise<unknown>,
 ) => {
   switch (request.query) {
     case 'createSession':
@@ -20,7 +20,7 @@ const evaluateMessage = async (
       break
     case 'joinSession':
       if (request.sessionID) {
-        await joinSession(request.sessionID)
+        await joinSession({ sessionID: request.sessionID })
         sendResponse({
           success: true,
         })
@@ -49,7 +49,7 @@ const evaluateMessage = async (
 
 export const listenForBrowserActionEvents = (
   createSession: () => Promise<string>,
-  joinSession: (sessionID: string) => Promise<unknown>,
+  joinSession: ({ sessionID }: { sessionID: string }) => Promise<unknown>,
 ): void => {
   if (typeof chrome?.runtime?.onMessage?.addListener === 'function') {
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {

--- a/src/plugin/contentScript/onElementRemoved.ts
+++ b/src/plugin/contentScript/onElementRemoved.ts
@@ -1,14 +1,15 @@
 export const onElementRemoved = (element: HTMLElement, callback: () => void) => {
-  if (element.parentElement) {
+  if (document.body.contains(element)) {
     const observer = new MutationObserver(() => {
       // Node was removed from DOM if parent is null
-      if (element.parentElement === null) {
+      if (!document.body.contains(element)) {
         observer.disconnect()
         callback()
       }
     })
 
-    observer.observe(element.parentElement, {
+    // Observe entire DOM in case element isn't just deleted, but it's deleted together with it's ancestor(s)
+    observer.observe(document.documentElement, {
       attributes: false,
       attributeOldValue: false,
       characterData: false,

--- a/src/plugin/contentScript/onElementRemoved.ts
+++ b/src/plugin/contentScript/onElementRemoved.ts
@@ -1,0 +1,22 @@
+export const onElementRemoved = (element: HTMLElement, callback: () => void) => {
+  if (element.parentElement) {
+    const observer = new MutationObserver(() => {
+      // Node was removed from DOM if parent is null
+      if (element.parentElement === null) {
+        observer.disconnect()
+        callback()
+      }
+    })
+
+    observer.observe(element.parentElement, {
+      attributes: false,
+      attributeOldValue: false,
+      characterData: false,
+      characterDataOldValue: false,
+      childList: true,
+      subtree: true,
+    })
+  } else {
+    callback()
+  }
+}

--- a/src/plugin/user_interface/App.vue
+++ b/src/plugin/user_interface/App.vue
@@ -21,6 +21,10 @@ html, body {
   padding: 0;
   margin: 0;
   min-height: 100vh;
+
+  input:disabled {
+    color: #AAA;
+  }
 }
 
 * {

--- a/src/server/SessionManager/SessionManager.ts
+++ b/src/server/SessionManager/SessionManager.ts
@@ -49,9 +49,16 @@ export const sessionManager = (sessions: SessionsObject): WebsocketRequestHandle
       console.log(`Socket from ${clientIP} closed`)
 
       if (session.webSockets.size === 0) {
-        console.log(`Session ${sessionID} is now empty. Deleting session. (Currently ${Object.values(sessions).length})`)
-        delete sessions[sessionID]
-        console.log(`Now ${Object.values(sessions).length} sessions`)
+        console.log(`Session ${sessionID} is now empty. Waiting one minute for potential re-joins before deleting it`)
+        setTimeout(() => {
+          if (session.webSockets.size === 0) {
+            console.log(`Session ${sessionID} is now empty. Deleting session. (Currently ${Object.values(sessions).length})`)
+            delete sessions[sessionID]
+            console.log(`Now ${Object.values(sessions).length} sessions`)
+          } else {
+            console.log(`Session ${sessionID} is no longer empty, so it won't be deleted.`)
+          }
+        }, 60 * 1000)
       }
     }
   }


### PR DESCRIPTION
This PR mostly focusses on re-attaching to a video once the used video is removed from the DOM while keeping the same `sessionID` (while also fixing some other minor stuff). This allows users to keep their session throughout multiple episodes on Netflix and other SPAs. Page reloads are not supported yet.

Refers #21